### PR TITLE
conf: No SPDIF on Plantronics 3220 headset

### DIFF
--- a/src/conf/cards/USB-Audio.conf
+++ b/src/conf/cards/USB-Audio.conf
@@ -56,6 +56,7 @@ USB-Audio.pcm.iec958_device {
 	"Logitech USB Headset" 999
 	"Logitech USB Headset H540" 999
 	"Logitech Wireless Headset" 999
+	"Plantronics Blackwire 3220 Seri" 999
 	"Plantronics GameCom 780" 999
 	"Plantronics USB Headset" 999
 	"Plantronics Wireless Audio" 999


### PR DESCRIPTION
The Plantronics Blackwire 3220 Series headset (USB ID 047f:c056) shows up in GNOME Settings with a non-existent digital output. Add it to the list to suppress this.